### PR TITLE
add argument autocompletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Install and build the project:
 - [x] delete a file or a directory
 - [x] move/rename a file or a directory
 - [x] upload a specific file
+- [ ] live syncs
+
+# Shell ergonomics
+
+- [x] autocomplete
+- [ ] globbing
 - [ ] upload a directory and all its files and subdirectories recursively
 
 # Commands

--- a/shell/arguments.go
+++ b/shell/arguments.go
@@ -1,0 +1,58 @@
+package shell
+
+import "strings"
+
+func parseArguments(line string) []string {
+	words := [][]rune{}
+
+	words = append(words, make([]rune, 0))
+	slashes := 0
+	args := 0
+	for _, v := range line {
+		if v == ' ' {
+			// Consume blank spaces between args
+			if len(words[args]) == 0 {
+				continue
+			}
+
+			if slashes > 0 && (slashes%2) == 1 {
+				// Found escaped space within argument
+				words[args] = append(words[args], v)
+			} else {
+				// End of argument
+				words = append(words, make([]rune, 0))
+				args = args + 1
+			}
+
+			slashes = 0
+			continue
+		}
+
+		if v == '\\' {
+			slashes = slashes + 1
+		} else {
+			slashes = 0
+		}
+
+		words[args] = append(words[args], v)
+	}
+
+	result := make([]string, 0)
+	for _, w := range words {
+		if len(w) == 0 {
+			continue
+		}
+
+		result = append(result, string(w))
+	}
+
+	return result
+}
+
+func escapeSpaces(s string) string {
+	return strings.Replace(s, " ", "\\ ", -1)
+}
+
+func unescapeSpaces(s string) string {
+	return strings.Replace(s, "\\ ", " ", -1)
+}

--- a/shell/arguments_test.go
+++ b/shell/arguments_test.go
@@ -1,0 +1,15 @@
+package shell
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseArguments(t *testing.T) {
+	assert.Equal(t, []string{"foo", "bar", "baz"}, parseArguments("foo bar baz"))
+	assert.Equal(t, []string{"foo", "bar", "baz"}, parseArguments(" foo   bar baz  "))
+	assert.Equal(t, []string{"foo", "bar\\ baz"}, parseArguments(" foo  bar\\ baz  "))
+	assert.Equal(t, []string{"foo", "bar\\ baz", "bax"}, parseArguments(" foo  bar\\ baz bax"))
+
+}

--- a/shell/cd.go
+++ b/shell/cd.go
@@ -1,11 +1,14 @@
 package shell
 
-import "github.com/abiosoft/ishell"
+import (
+	"github.com/abiosoft/ishell"
+)
 
 func cdCmd(ctx *ShellCtxt) *ishell.Cmd {
 	return &ishell.Cmd{
-		Name: "cd",
-		Help: "change directory",
+		Name:      "cd",
+		Help:      "change directory",
+		Completer: createDirCompleter(ctx),
 		Func: func(c *ishell.Context) {
 			if len(c.Args) == 0 {
 				return

--- a/shell/completer.go
+++ b/shell/completer.go
@@ -1,0 +1,114 @@
+package shell
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/juruen/rmapi/log"
+	"github.com/juruen/rmapi/model"
+)
+
+func prefixToNodeDir(ctx *ShellCtxt, s []string) (*model.Node, string) {
+	node := ctx.node
+	isPrefix := len(s) > 0 && s[len(s)-1] != ""
+
+	log.Trace.Println("isPrefix", isPrefix)
+
+	if !isPrefix {
+		return node, ""
+	}
+
+	prefix := unescapeSpaces(s[len(s)-1])
+
+	log.Trace.Println("prefix", prefix)
+
+	node, err := ctx.api.Filetree.NodeByPath(prefix, ctx.node)
+
+	// Prefix matches an entry
+	if err == nil {
+		if node.IsDirectory() {
+			if strings.HasSuffix(prefix, "/") {
+				return node, prefix
+			} else {
+				return node.Parent, path.Dir(prefix)
+			}
+		}
+	}
+
+	base := path.Base(prefix)
+
+	log.Trace.Println("base", base)
+
+	if base == prefix {
+		return ctx.node, ""
+	}
+
+	dir := path.Dir(prefix)
+
+	log.Trace.Println("dir", dir)
+
+	node, err = ctx.api.Filetree.NodeByPath(dir, ctx.node)
+
+	if err != nil {
+		return nil, ""
+	}
+
+	return node, dir
+}
+
+type nodeCheckFn func(*model.Node) bool
+
+func createDirCompleter(ctx *ShellCtxt) func([]string) []string {
+	return createCompleter(ctx, func(n *model.Node) bool { return n.IsDirectory() })
+}
+
+func createFileCompleter(ctx *ShellCtxt) func([]string) []string {
+	return createCompleter(ctx, func(n *model.Node) bool { return n.IsFile() })
+}
+
+func createEntryCompleter(ctx *ShellCtxt) func([]string) []string {
+	return createCompleter(ctx, func(n *model.Node) bool { return true })
+}
+
+func createCompleter(ctx *ShellCtxt, check nodeCheckFn) func([]string) []string {
+	return func(s []string) []string {
+		options := make([]string, 0)
+
+		log.Trace.Println("completer:", s, len(s))
+
+		node, dir := prefixToNodeDir(ctx, s)
+
+		if node == nil {
+			return options
+		}
+
+		for _, n := range node.Children {
+			if !check(n) {
+				continue
+			}
+
+			var entry string
+			if n.IsDirectory() {
+				entry = fmt.Sprintf("%s/", n.Name())
+			} else {
+				entry = fmt.Sprintf("%s", n.Name())
+			}
+
+			if dir != "" {
+				if !strings.HasSuffix(dir, "/") {
+					dir += "/"
+				}
+				entry = fmt.Sprintf("%s%s", dir, entry)
+			}
+
+			entry = escapeSpaces(entry)
+
+			options = append(options, entry)
+		}
+
+		log.Trace.Println("options", options)
+
+		return options
+	}
+}

--- a/shell/custom_completer.go
+++ b/shell/custom_completer.go
@@ -1,0 +1,58 @@
+package shell
+
+import (
+	"strings"
+)
+
+type cmdToCompleter map[string]func([]string) []string
+
+type shellPathCompleter struct {
+	cmdCompleter cmdToCompleter
+}
+
+func (ic shellPathCompleter) Do(line []rune, pos int) (newLine [][]rune, length int) {
+	if len(ic.cmdCompleter) == 0 {
+		return nil, len(line)
+	}
+
+	words := parseArguments(string(line))
+
+	var cWords []string
+	prefix := ""
+	if len(words) > 0 && line[pos-1] != ' ' {
+		prefix = words[len(words)-1]
+		cWords = ic.getWords(words[:len(words)-1], prefix)
+	} else {
+		cWords = ic.getWords(words, prefix)
+	}
+
+	var suggestions [][]rune
+	for _, w := range cWords {
+		if strings.HasPrefix(w, prefix) {
+			suggestions = append(suggestions, []rune(strings.TrimPrefix(w, prefix)))
+		}
+	}
+	if len(suggestions) == 1 && prefix != "" && string(suggestions[0]) == "" {
+		suggestions = [][]rune{[]rune(" ")}
+	}
+	return suggestions, len(prefix)
+}
+
+func (ic shellPathCompleter) getWords(w []string, prefix string) []string {
+	if len(w) == 0 {
+		return make([]string, 0)
+	}
+
+	completer, ok := ic.cmdCompleter[w[0]]
+	if !ok {
+		return make([]string, 0)
+	}
+
+	args := make([]string, len(w))
+	for i, v := range w[1:len(w)] {
+		args[i] = v
+	}
+	args = append(args, prefix)
+
+	return completer(args)
+}

--- a/shell/get.go
+++ b/shell/get.go
@@ -8,8 +8,9 @@ import (
 
 func getCmd(ctx *ShellCtxt) *ishell.Cmd {
 	return &ishell.Cmd{
-		Name: "get",
-		Help: "copy remote file to local",
+		Name:      "get",
+		Help:      "copy remote file to local",
+		Completer: createEntryCompleter(ctx),
 		Func: func(c *ishell.Context) {
 			if len(c.Args) == 0 {
 				c.Println("missing source file")

--- a/shell/mget.go
+++ b/shell/mget.go
@@ -11,8 +11,9 @@ import (
 
 func mgetCmd(ctx *ShellCtxt) *ishell.Cmd {
 	return &ishell.Cmd{
-		Name: "mget",
-		Help: "recursively copy remote directory to local",
+		Name:      "mget",
+		Help:      "recursively copy remote directory to local",
+		Completer: createDirCompleter(ctx),
 		Func: func(c *ishell.Context) {
 			if len(c.Args) == 0 {
 				c.Println("missing source dir")

--- a/shell/mkdir.go
+++ b/shell/mkdir.go
@@ -8,8 +8,9 @@ import (
 
 func mkdirCmd(ctx *ShellCtxt) *ishell.Cmd {
 	return &ishell.Cmd{
-		Name: "mkdir",
-		Help: "create a directory",
+		Name:      "mkdir",
+		Help:      "create a directory",
+		Completer: createDirCompleter(ctx),
 		Func: func(c *ishell.Context) {
 			if len(c.Args) == 0 {
 				c.Println("missing directory")

--- a/shell/mv.go
+++ b/shell/mv.go
@@ -8,8 +8,9 @@ import (
 
 func mvCmd(ctx *ShellCtxt) *ishell.Cmd {
 	return &ishell.Cmd{
-		Name: "mv",
-		Help: "mv file or directory",
+		Name:      "mv",
+		Help:      "mv file or directory",
+		Completer: createEntryCompleter(ctx),
 		Func: func(c *ishell.Context) {
 			if len(c.Args) == 1 {
 				return

--- a/shell/rm.go
+++ b/shell/rm.go
@@ -4,8 +4,9 @@ import "github.com/abiosoft/ishell"
 
 func rmCmd(ctx *ShellCtxt) *ishell.Cmd {
 	return &ishell.Cmd{
-		Name: "rm",
-		Help: "delete entry",
+		Name:      "rm",
+		Help:      "delete entry",
+		Completer: createEntryCompleter(ctx),
 		Func: func(c *ishell.Context) {
 			if len(c.Args) == 0 {
 				return

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -19,6 +19,16 @@ func (ctx *ShellCtxt) prompt() string {
 	return fmt.Sprintf("[%s]>", ctx.path)
 }
 
+func setCustomCompleter(shell *ishell.Shell) {
+	cmdCompleter := make(cmdToCompleter)
+	for _, cmd := range shell.Cmds() {
+		cmdCompleter[cmd.Name] = cmd.Completer
+	}
+
+	completer := shellPathCompleter{cmdCompleter}
+	shell.CustomCompleter(completer)
+}
+
 func RunShell(apiCtx *api.ApiCtx) {
 	shell := ishell.New()
 	ctx := &ShellCtxt{apiCtx.Filetree.Root(), apiCtx, apiCtx.Filetree.Root().Name()}
@@ -35,6 +45,8 @@ func RunShell(apiCtx *api.ApiCtx) {
 	shell.AddCmd(rmCmd(ctx))
 	shell.AddCmd(mvCmd(ctx))
 	shell.AddCmd(putCmd(ctx))
+
+	setCustomCompleter(shell)
 
 	if len(os.Args) > 1 {
 		shell.Process(os.Args[1:]...)


### PR DESCRIPTION
Add autocompletion for arguments. This is nice to not have to type paths to directories and documents, which are generally long.

The shell we use:  https://github.com/abiosoft/ishell doesn't support very well arguments that contain spaces.

I had to roll out some custom autocompletion code to escape spaces. Basic functionality is there but there are still some features to add. 