### PR TITLE
Put all

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ rmapi
 
 # Vendor sources
 vendor/*/
+
+# Test docs
+*.pdf
+*.epub

--- a/shell/put.go
+++ b/shell/put.go
@@ -8,32 +8,69 @@ import (
 	"github.com/juruen/rmapi/util"
 )
 
+// Requests upload doc to cloud
+func putDoc(pC *ishell.Context, ctx *ShellCtxt, pSrcName string, pDstDir string) int {
+
+	docName := util.DocPathToName(pSrcName)
+
+	_, err := ctx.api.Filetree.NodeByPath(docName, ctx.node)
+	if err == nil {
+
+		pC.Err(errors.New(fmt.Sprint(pSrcName, " already exists")))
+
+		return -1
+	}
+
+	pC.Printf("uploading: [%s]...", pSrcName)
+
+	document, err := ctx.api.UploadDocument(pDstDir, pSrcName)
+
+	if err != nil {
+		pC.Err(errors.New(fmt.Sprint("Failed to upload file ", pSrcName, err.Error())))
+		return -1
+	}
+
+	pC.Println(" complete")
+
+	ctx.api.Filetree.AddDocument(*document)
+
+	return 1
+}
+
+func printUsage(pC *ishell.Context) {
+	pC.Println("Usage:\n")
+	pC.Println("    [/]> put  <file-list>")
+	pC.Println("    [/]> put  <file-list> <dst-dir>\n")
+	pC.Println("<file-list> can be * (all files) or, 1 or more files separated by spaces\n")
+}
+
 func putCmd(ctx *ShellCtxt) *ishell.Cmd {
 	return &ishell.Cmd{
 		Name:      "put",
-		Help:      "copy a local document to cloud",
+		Help:      "copy local documents to cloud",
 		Completer: createFsEntryCompleter(),
 		Func: func(c *ishell.Context) {
 			if len(c.Args) == 0 {
-				c.Println("missing source file")
+				c.Println("missing source files\n")
+
+				printUsage(c)
 				return
 			}
 
-			srcName := c.Args[0]
+			// Total number of arguments.
+			argsLen := len(c.Args)
 
-			docName := util.DocPathToName(srcName)
+			// Check if last argument is a directory.
+			
 
-			_, err := ctx.api.Filetree.NodeByPath(docName, ctx.node)
-			if err == nil {
-				c.Err(errors.New("entry already exists"))
-				return
-			}
-
+			// Extract the destination directory data if available.
 			dstDir := ctx.node.Id()
-			if len(c.Args) == 2 {
-				node, err := ctx.api.Filetree.NodeByPath(c.Args[1], ctx.node)
+
+			if len(c.Args) > 1 {
+				node, err := ctx.api.Filetree.NodeByPath(c.Args[(argsLen-1)], ctx.node)
 
 				if err != nil || node.IsFile() {
+					// Make one?
 					c.Err(errors.New("directory doesn't exist"))
 					return
 				}
@@ -41,18 +78,28 @@ func putCmd(ctx *ShellCtxt) *ishell.Cmd {
 				dstDir = node.Id()
 			}
 
-			c.Printf("uploading: [%s]...", srcName)
+			putDoc(c, ctx, c.Args[0], dstDir)
 
-			document, err := ctx.api.UploadDocument(dstDir, srcName)
+			// ioutil.
 
-			if err != nil {
-				c.Err(errors.New(fmt.Sprint("Failed to upload file", srcName, err.Error())))
-				return
-			}
+			// srcName := c.Args[0]
 
-			c.Println("OK")
+			// docName := util.DocPathToName(srcName)
 
-			ctx.api.Filetree.AddDocument(*document)
+			// c.Printf("uploading: [%s]...", srcName)
+
+			// document, err := ctx.api.UploadDocument(dstDir, srcName)
+
+			// if err != nil {
+			// 	c.Err(errors.New(fmt.Sprint("Failed to upload file", srcName, err.Error())))
+			// 	return
+			// }
+
+			// c.Println(" complete")
+
+			// ctx.api.Filetree.AddDocument(*document)
+
+			// End of function
 		},
 	}
 }

--- a/shell/put.go
+++ b/shell/put.go
@@ -39,8 +39,8 @@ func putDoc(pC *ishell.Context, ctx *ShellCtxt, pSrcName string, pDstDir string)
 
 func printUsage(pC *ishell.Context) {
 	pC.Println("Usage:\n")
-	pC.Println("    [/]> put  <file-list>")
-	pC.Println("    [/]> put  <file-list> <dst-dir>\n")
+	pC.Println("    [/]> put <file-list>")
+	pC.Println("    [/]> put <file-list> -d <dst-dir>\n")
 	pC.Println("<file-list> can be * (all files) or, 1 or more files separated by spaces\n")
 }
 
@@ -60,17 +60,31 @@ func putCmd(ctx *ShellCtxt) *ishell.Cmd {
 			// Total number of arguments.
 			argsLen := len(c.Args)
 
-			// Check if last argument is a directory.
-			
+			// Bool to flag if last argument is a dir (default -> true)
+			userDir := false
+			dIndex := -1
 
-			// Extract the destination directory data if available.
+			// Check if -d option is present.
+			for index, str := range c.Args {
+				if str == "-d" {
+					userDir = true
+					dIndex = index
+					break
+				}
+			}
+
 			dstDir := ctx.node.Id()
 
-			if len(c.Args) > 1 {
+			if userDir {
+				// Number of arguments for option -d must be 1
+				if argsLen > dIndex+2 {
+					c.Err(errors.New("too many arguments for option -d"))
+					return
+				}
+
 				node, err := ctx.api.Filetree.NodeByPath(c.Args[(argsLen-1)], ctx.node)
 
 				if err != nil || node.IsFile() {
-					// Make one?
 					c.Err(errors.New("directory doesn't exist"))
 					return
 				}


### PR DESCRIPTION
Hello. I was happy to find rmapi because I use Linux.

This is a feature I wanted and added. One can call put with an * and a '-d' option to specify the directory which will upload all the .pdf and .epub files. The input method as available in the master branch still works.

I don't know if the code needs to meet a specific requirement, so you can reject this if you don't like it. Though, I would like to know if there is an IRC group or anything similar.

![rm-put-all](https://user-images.githubusercontent.com/5787026/42063754-7351e63e-7b33-11e8-8628-1b8afe26775a.png)

