### PR TITLE
Increased timeout of http client to 5 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## rmapi 0.0.5 (???)
+
+* Increased http timeout to 5 minutes to enable upload of larger files
+
 ## rmapi 0.0.4 (October 1, 2018)
 
 * Windows fixes

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -40,7 +40,7 @@ type HttpClientCtx struct {
 }
 
 func CreateHttpClientCtx(tokens model.AuthTokens) HttpClientCtx {
-	var httpClient = &http.Client{Timeout: 60 * time.Second}
+	var httpClient = &http.Client{Timeout: 5 * 60 * time.Second}
 
 	return HttpClientCtx{httpClient, tokens}
 }


### PR DESCRIPTION
Fixed issue #28 
Tried it out for a 30MB pdf file and it worked.