### PR TITLE
Add find command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 * Fix panic when autocompleting the "ls" command
 
+* Add find command
+
 ## rmapi 0.0.4 (October 1, 2018)
 
 * Windows fixes

--- a/README.md
+++ b/README.md
@@ -64,11 +64,19 @@ are directories, and `[f]` if they are files.
 
 ## Change current directory
 
-Use `cd` to change the current directory to any other directory in the hiearchy.
+Use `cd` to change the current directory to any other directory in the hierarchy.
+
+## Find a file
+
+The command  `find` takes one or two arguments.
+
+If only the first argument is passed, all entries from that point are printed recursively.
+
+When the second argument is also passed, a regexp is expected, and only those entries that match the regexp are printed.
 
 ## Upload a file
 
-Use `put path_to_local_file` to upload a file  to the current dirctory.
+Use `put path_to_local_file` to upload a file  to the current directory.
 
 You can also specify the destination directory:
 

--- a/shell/find.go
+++ b/shell/find.go
@@ -1,0 +1,58 @@
+package shell
+
+import (
+	"errors"
+	"github.com/abiosoft/ishell"
+	"github.com/juruen/rmapi/filetree"
+	"github.com/juruen/rmapi/model"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+func findCmd(ctx *ShellCtxt) *ishell.Cmd {
+	return &ishell.Cmd{
+		Name:      "find",
+		Help:      "find files recursively, usage: find dir [regex]",
+		Completer: createDirCompleter(ctx),
+		Func: func(c *ishell.Context) {
+			start := c.Args[0]
+
+			startNode, err := ctx.api.Filetree.NodeByPath(start, ctx.node)
+
+			if err != nil {
+				c.Err(errors.New("start directory doesn't exist"))
+				return
+			}
+
+			var matchRegexp *regexp.Regexp
+			if len(c.Args) == 2 {
+				matchRegexp = regexp.MustCompile(c.Args[1])
+				if matchRegexp == nil {
+					c.Err(errors.New("failed to compile regexp"))
+					return
+				}
+			}
+
+			filetree.WalkTree(startNode, filetree.FileTreeVistor{
+				Visit:func(node *model.Node, path []string) bool {
+					entryName := filepath.Join(strings.Join(path, "/"), node.Name())
+
+					if matchRegexp == nil {
+						c.Println(entryName)
+						return false
+					}
+
+					if ! matchRegexp.Match([]byte(entryName)) {
+						return false
+					}
+
+					c.Println(entryName)
+
+					return false
+				},
+			})
+		},
+	}
+}
+

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -64,6 +64,7 @@ func RunShell(apiCtx *api.ApiCtx) error {
 	shell.AddCmd(versionCmd(ctx))
 	shell.AddCmd(statCmd(ctx))
 	shell.AddCmd(getACmd(ctx))
+	shell.AddCmd(findCmd(ctx))
 
 	setCustomCompleter(shell)
 


### PR DESCRIPTION
The command  `find` takes one or two arguments.

If only the first argument is passed, all entries from that point are printed recursively.

When the second argument is also passed, a regexp is expected, and only those entries that match the regexp are printed.

This addresses #47 