### PR TITLE
Use env var RMAPI_CONFIG to set config file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,5 +156,6 @@ rMAPI will set the exit code to `0` if the command succeedes, or `1` if it fails
 
 # Environment variables
 
+- `RMAPI_CONFIG`: filepath used to store authentication tokens. When not set, rmapi uses the file `.rmapi` in the home directory of the current user.
 - `RMAPI_TRACE=1`: enable trace logging.
 - `RMAPI_USE_HIDDEN_FILES=1`: use and traverse hidden files/directories (they are ignored by default).

--- a/config/config.go
+++ b/config/config.go
@@ -13,9 +13,15 @@ import (
 
 const (
 	defaultConfigFile = ".rmapi"
+	configFileEnvVar = "RMAPI_CONFIG"
 )
 
 func ConfigPath() string {
+	configFile, ok := os.LookupEnv(configFileEnvVar)
+	if ok {
+		return configFile
+	}
+
 	user, err := user.Current()
 	if err != nil {
 		log.Error.Panicln("failed to get current user:", err)


### PR DESCRIPTION
If not set, fall back to using .rmapi in user home dir as before.
This fixes #59.