### PR TITLE
Update archive read method signature to reduce memory footprint

### DIFF
--- a/annotations/pdf.go
+++ b/annotations/pdf.go
@@ -35,7 +35,12 @@ func (p PdfGenerator) Generate() error {
 
 	zip := archive.NewZip()
 
-	err = zip.Read(file)
+	fi, err := file.Stat()
+	if err != nil {
+		return err
+	}
+
+	err = zip.Read(file, fi.Size())
 	if err != nil {
 		return err
 	}

--- a/archive/reader.go
+++ b/archive/reader.go
@@ -3,7 +3,6 @@ package archive
 import (
 	"archive/zip"
 	"bufio"
-	"bytes"
 	"encoding/json"
 	"errors"
 	"io"
@@ -16,8 +15,8 @@ import (
 )
 
 // Read fills a Zip parsing a Remarkable archive file.
-func (z *Zip) Read(r io.Reader) error {
-	zr, err := zipReaderFromIOReader(r)
+func (z *Zip) Read(r io.ReaderAt, size int64) error {
+	zr, err := zip.NewReader(r, size)
 	if err != nil {
 		return err
 	}
@@ -304,22 +303,4 @@ func zipExtFinder(zr *zip.Reader, ext string) ([]*zip.File, error) {
 	}
 
 	return files, nil
-}
-
-// zipReaderFromIOReader transforms a io.Reader to a zip.Reader.
-func zipReaderFromIOReader(r io.Reader) (*zip.Reader, error) {
-	b, err := ioutil.ReadAll(r)
-	if err != nil {
-		return nil, err
-	}
-
-	// use a bytes.Reader as it implements io.ReadAt
-	br := bytes.NewReader(b)
-
-	zr, err := zip.NewReader(br, br.Size())
-	if err != nil {
-		return nil, err
-	}
-
-	return zr, nil
 }

--- a/archive/reader_test.go
+++ b/archive/reader_test.go
@@ -15,8 +15,13 @@ func TestRead(t *testing.T) {
 	}
 	defer file.Close()
 
+	fi, err := file.Stat()
+	if err != nil {
+		t.Error(err)
+	}
+
 	// read file into note
-	err = zip.Read(file)
+	err = zip.Read(file, fi.Size())
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Hello @juruen,

Quick PR to answer #74 

By taking an `io.Reader`, it was maybe cleaner in terms of API but as the underlying `archive/zip` package should read from an `io.ReaderAt` and a `size`, we had to transform the `io.Reader` into a `io.ReaderAt` and this implied an unecessary buffering of the file (it was done with func `zipReaderFromIOReader`).

I think it is better to be transparent and to use a more explicit API.

Loric