### PR TITLE
Add Dockerfile and README instructions for use.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM golang:alpine AS builder
+
+ENV PATH /go/bin:/usr/local/go/bin:$PATH
+ENV GOPATH /go
+ENV SOURCEPATH ${GOPATH}/src/github.com/juruen/rmapi
+
+RUN apk add --no-cache \
+    bash
+
+COPY . ${SOURCEPATH}
+
+RUN set -x \
+    && cd ${SOURCEPATH} \
+    && go build . \
+    && mv rmapi /usr/bin/rmapi
+
+
+FROM alpine:latest
+
+COPY --from=builder /usr/bin/rmapi /usr/bin/rmapi
+
+RUN adduser -D -u 1000 user \
+    && chown -R user /home/user
+
+USER user
+
+ENV USER user
+
+WORKDIR /home/user
+
+ENTRYPOINT [ "rmapi" ]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,26 @@ Install and build the project:
 
 You can download an already built version for either Linux or OSX from [releases](https://github.com/juruen/rmapi/releases).
 
+## Docker
+
+First clone this repository, then build a local container like
+
+```
+docker build -t rmapi .
+```
+
+and run by mounting the .rmapi folder
+
+```
+docker run -v $HOME/.rmapi/:/home/user/.rmapi/ -it rmapi
+```
+
+Issue non-interactive commands by appending to the `docker run` command:
+
+```
+docker run -v $HOME/.rmapi/:/home/user/.rmapi/ rmapi help
+```
+
 # API support
 
 - [x] list files and directories


### PR DESCRIPTION
Dockerfile produces a small-as-possible container, just alpine and the rmapi binary.

Also added a small section to the README about it.

Could be handy to get this up on dockerhub; then it'd be easy to extend by copying the binary out of it with a `COPY --from`.

Closes #70