### PR TITLE
Fix put bug when directory supplied

### DIFF
--- a/shell/put.go
+++ b/shell/put.go
@@ -23,25 +23,27 @@ func putCmd(ctx *ShellCtxt) *ishell.Cmd {
 
 			docName := util.DocPathToName(srcName)
 
-			_, err := ctx.api.Filetree.NodeByPath(docName, ctx.node)
-			if err == nil {
-				c.Err(errors.New("entry already exists"))
-				return
-			}
+			node := ctx.node
+			var err error
 
-			dstDir := ctx.node.Id()
 			if len(c.Args) == 2 {
-				node, err := ctx.api.Filetree.NodeByPath(c.Args[1], ctx.node)
+				node, err = ctx.api.Filetree.NodeByPath(c.Args[1], ctx.node)
 
 				if err != nil || node.IsFile() {
 					c.Err(errors.New("directory doesn't exist"))
 					return
 				}
+			}
 
-				dstDir = node.Id()
+			_, err = ctx.api.Filetree.NodeByPath(docName, node)
+			if err == nil {
+				c.Err(errors.New("entry already exists"))
+				return
 			}
 
 			c.Printf("uploading: [%s]...", srcName)
+
+			dstDir := node.Id()
 
 			document, err := ctx.api.UploadDocument(dstDir, srcName)
 


### PR DESCRIPTION
This commit aims to fixes a bug (#86) where uploading a file would fail if a file with the same name already exists in the root directory. With this change we first check if there is a second command line argument for the directory, and *then* check if there is a filename conflict.

P.S.: I don't usually write in Go, so please excuse (and feel free to fix) any stylistic errors.