### PR TITLE
quickfix to make thumbnails optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,3 +177,6 @@ rMAPI will set the exit code to `0` if the command succeedes, or `1` if it fails
 - `RMAPI_CONFIG`: filepath used to store authentication tokens. When not set, rmapi uses the file `.rmapi` in the home directory of the current user.
 - `RMAPI_TRACE=1`: enable trace logging.
 - `RMAPI_USE_HIDDEN_FILES=1`: use and traverse hidden files/directories (they are ignored by default).
+- `RMAPI_THUMBNAILS`: generate a thumbnail of the first page of a pdf document
+- `RMAPI_AUTH`: override the default authorization url
+- `RMAPI_DOC`: override the default document storage url

--- a/util/zipdoc.go
+++ b/util/zipdoc.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"image/jpeg"
 	"io/ioutil"
+	"os"
 	"strings"
 
 	"bytes"
@@ -28,7 +29,6 @@ type zipDocumentContent struct {
 }
 
 func makeThumbnail(pdf []byte) ([]byte, error) {
-
 	reader, err := model.NewPdfReader(bytes.NewReader(pdf))
 	if err != nil {
 		return nil, err
@@ -88,7 +88,8 @@ func CreateZipDocument(id, srcPath string) (string, error) {
 	f.Write(pdf)
 
 	//try to create a thumbnail
-	if ext == "pdf" {
+	//due to a bug somewhere in unipdf the generation is opt-in
+	if ext == "pdf" && os.Getenv("RMAPI_THUMBNAILS") != "" {
 		thumbnail, err := makeThumbnail(pdf)
 		if err != nil {
 			log.Error.Println("cannot generate thumbnail", err)


### PR DESCRIPTION
sorry for the pull request flood. until i find out why unipdf hangs, we should disable this or make it opt-in or toggleable