### PR TITLE
fixes #111 set dummyDocument to false

### DIFF
--- a/archive/file.go
+++ b/archive/file.go
@@ -18,6 +18,7 @@ type Zip struct {
 // NewZip creates a File with sane defaults.
 func NewZip() *Zip {
 	content := Content{
+		DummyDocument: false,
 		ExtraMetadata: ExtraMetadata{
 			LastBrushColor:           "Black",
 			LastBrushThicknessScale:  "2",
@@ -32,6 +33,7 @@ func NewZip() *Zip {
 			LastPencilThicknessScale: "2",
 			LastTool:                 "SharpPencil",
 			ThicknessScale:           "2",
+			LastFinelinerv2Size:      "1",
 		},
 		FileType:       "",
 		FontName:       "",
@@ -84,6 +86,7 @@ type Layer struct {
 
 // Content represents the structure of a .content json file.
 type Content struct {
+	DummyDocument bool          `json:"dummyDocument"`
 	ExtraMetadata ExtraMetadata `json:"extraMetadata"`
 
 	// FileType is "pdf", "epub" or empty for a simple note
@@ -117,6 +120,7 @@ type ExtraMetadata struct {
 	LastPencilThicknessScale string `json:"LastPencilThicknessScale"`
 	LastTool                 string `json:"LastTool"`
 	ThicknessScale           string `json:"ThicknessScale"`
+	LastFinelinerv2Size      string `json:"LastFinelinerv2Size"`
 }
 
 // Transform is a struct contained into a Content struct.

--- a/archive/zipdoc.go
+++ b/archive/zipdoc.go
@@ -16,17 +16,6 @@ import (
 	"github.com/unidoc/unipdf/v3/render"
 )
 
-type zipDocumentContent struct {
-	ExtraMetadata  map[string]string `json:"extraMetadata"`
-	FileType       string            `json:"fileType"`
-	PageCount      int               `json:"pageCount"`
-	LastOpenedPage int               `json:"lastOpenedPage"`
-	LineHeight     int               `json:"lineHeight"`
-	Margins        int               `json:"margins"`
-	TextScale      int               `json:"textScale"`
-	Transform      map[string]string `json:"transform"`
-}
-
 func makeThumbnail(pdf []byte) ([]byte, error) {
 	reader, err := pdfmodel.NewPdfReader(bytes.NewReader(pdf))
 	if err != nil {
@@ -130,8 +119,6 @@ func CreateZipDocument(id, srcPath string) (zipPath string, err error) {
 	}
 	f.Write(make([]byte, 0))
 
-	//create thumbnail
-
 	// Create content content
 	f, err = w.Create(fmt.Sprintf("%s.content", id))
 	if err != nil {
@@ -175,15 +162,30 @@ func CreateZipDirectory(id string) (string, error) {
 }
 
 func createZipContent(ext string) (string, error) {
-	c := zipDocumentContent{
-		make(map[string]string),
-		ext,
-		0,
-		0,
-		-1,
-		180,
-		1,
-		make(map[string]string),
+	c := Content{
+		DummyDocument: false,
+		ExtraMetadata: ExtraMetadata{
+			LastPen:             "Finelinerv2",
+			LastTool:            "Finelinerv2",
+			LastFinelinerv2Size: "1",
+		},
+		FileType:       ext,
+		PageCount:      0,
+		LastOpenedPage: 0,
+		LineHeight:     -1,
+		Margins:        180,
+		TextScale:      1,
+		Transform: Transform{
+			M11: 1,
+			M12: 0,
+			M13: 0,
+			M21: 0,
+			M22: 1,
+			M23: 0,
+			M31: 0,
+			M32: 0,
+			M33: 1,
+		},
 	}
 
 	cstring, err := json.Marshal(c)


### PR DESCRIPTION
it seems that because pages is null, uploaded documents are  marked as dummyDocument.
setting this to `false` seems to fix the problem.

also set the default tool to fineliner, per user setting would be nice