### PR TITLE
fix for #114, acrobat does not like line cap styles

### DIFF
--- a/annotations/pdf.go
+++ b/annotations/pdf.go
@@ -117,8 +117,6 @@ func (p *PdfGenerator) Generate() error {
 
 		contentCreator := contentstream.NewContentCreator()
 		contentCreator.Add_q()
-		contentCreator.Add_j("1")
-		contentCreator.Add_J("1")
 
 		for _, layer := range pageAnnotations.Data.Layers {
 			for _, line := range layer.Lines {


### PR DESCRIPTION
traced to the use of line cap/joint style, preventing the pdf from displaying correctly under windows with acrobat