### PR TITLE
Fix BrushSize parsing for v5 files

### DIFF
--- a/encoding/rm/unmarshal.go
+++ b/encoding/rm/unmarshal.go
@@ -100,15 +100,15 @@ func (r *reader) readLine() (Line, error) {
 		return line, fmt.Errorf("Failed to read line")
 	}
 
+	if err := binary.Read(r, binary.LittleEndian, &line.BrushSize); err != nil {
+		return line, fmt.Errorf("Failed to read line")
+	}
+
 	// this new attribute has been added in v5
 	if r.version == V5 {
 		if err := binary.Read(r, binary.LittleEndian, &line.Unknown); err != nil {
 			return line, fmt.Errorf("Failed to read line")
 		}
-	}
-
-	if err := binary.Read(r, binary.LittleEndian, &line.BrushSize); err != nil {
-		return line, fmt.Errorf("Failed to read line")
 	}
 
 	nbPoints, err := r.readNumber()

--- a/encoding/rm/unmarshal_test.go
+++ b/encoding/rm/unmarshal_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func testUnmarshalBinary(t *testing.T, fn string, ver Version) {
+func testUnmarshalBinary(t *testing.T, fn string, ver Version) *Rm {
 	b, err := ioutil.ReadFile(fn)
 	if err != nil {
 		t.Errorf("can't open %s file", fn)
@@ -25,10 +25,19 @@ func testUnmarshalBinary(t *testing.T, fn string, ver Version) {
 	t.Log(rm)
 
 	fmt.Println("unmarshaling complete")
+
+	return rm
 }
 
 func TestUnmarshalBinaryV5(t *testing.T) {
-	testUnmarshalBinary(t, "test_v5.rm", V5)
+	rm := testUnmarshalBinary(t, "test_v5.rm", V5)
+	for _, layer := range rm.Layers {
+		for _, line := range layer.Lines {
+			if line.BrushSize != 2.0 {
+				t.Error("Incorrectly parsing BrushSize")
+			}
+		}
+	}
 }
 
 func TestUnmarshalBinaryV3(t *testing.T) {


### PR DESCRIPTION
Hello! Very grateful for your work on this library.

I discovered that the current `unmarshal.go` is parsing the `BrushSize` in the wrong order for v5 files. The code is populating the brush size into the `Unknown` field by accident. This is a small PR to fix that (just change the order in which we are parsing) and also update the test to help prevent a regression in the future.