### PR TITLE
Possible typo fix in suggested curl command.

### DIFF
--- a/docs/tutorial-print-macosx.md
+++ b/docs/tutorial-print-macosx.md
@@ -19,7 +19,7 @@ Use `terminal` or `iterm` to get a terminal to run commands from it.
 Download `rmapi` with the following command:
 
 ```bash
-curl -L  https://github.com/juruen/rmapi/releases/download/v0.0.13/rmapi-macosx.zip -o rmapi.zip -o rmapi.zip -o rmapi.zip -o rmapi.zip -o rmapi.zip -o rmapi.zip -o rmapi.zip
+curl -L  https://github.com/juruen/rmapi/releases/download/v0.0.13/rmapi-macosx.zip -o rmapi.zip
 ```
 
 Alternatively, you can build it from sources.


### PR DESCRIPTION
(Wasn’t sure if these extra `-o rmapi.zip` flags and values were needed.)