### PR TITLE
Typo fix in suggested curl command for printing.

### DIFF
--- a/docs/tutorial-print-macosx.md
+++ b/docs/tutorial-print-macosx.md
@@ -79,7 +79,7 @@ Run the `Automator` app and create a   new `Print Plugin` document as shown belo
 
 ![Automator I](create-print-plugin.png)
 
-Selct a `Run Shell Script` action:
+Select a `Run Shell Script` action:
 
 ![Automator II](run-shell-script-1.png)
 

--- a/docs/tutorial-print-macosx.md
+++ b/docs/tutorial-print-macosx.md
@@ -19,7 +19,7 @@ Use `terminal` or `iterm` to get a terminal to run commands from it.
 Download `rmapi` with the following command:
 
 ```bash
-curl -L  https://github.com/juruen/rmapi/releases/download/v0.0.13/rmapi-macosx.zip -o rmapi.zip -o rmapi.zip -o rmapi.zip -o rmapi.zip -o rmapi.zip -o rmapi.zip -o rmapi.zip
+curl -L  https://github.com/juruen/rmapi/releases/download/v0.0.13/rmapi-macosx.zip -o rmapi.zip
 ```
 
 Alternatively, you can build it from sources.


### PR DESCRIPTION
Re-opening of https://github.com/juruen/rmapi/pull/164, I was mistaken in thinking these extra `-o rmapi.zip`s were needed.