### PR TITLE
fix:oom on low end devices, dont dump request/response when tracing n…

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -8,10 +8,11 @@ import (
 )
 
 var (
-	Trace   *log.Logger
-	Info    *log.Logger
-	Warning *log.Logger
-	Error   *log.Logger
+	Trace          *log.Logger
+	Info           *log.Logger
+	Warning        *log.Logger
+	Error          *log.Logger
+	TracingEnabled bool
 )
 
 func Init(
@@ -41,6 +42,7 @@ func InitLog() {
 	var trace io.Writer
 	if os.Getenv("RMAPI_TRACE") == "1" {
 		trace = os.Stdout
+		TracingEnabled = true
 	} else {
 		trace = ioutil.Discard
 	}

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -168,8 +168,10 @@ func (ctx HttpClientCtx) Request(authType AuthType, verb, url string, body io.Re
 	ctx.addAuthorization(request, authType)
 	request.Header.Add("User-Agent", RmapiUserAGent)
 
-	drequest, err := httputil.DumpRequest(request, true)
-	log.Trace.Printf("request: %s", string(drequest))
+	if log.TracingEnabled {
+		drequest, err := httputil.DumpRequest(request, true)
+		log.Trace.Printf("request: %s %v", string(drequest), err)
+	}
 
 	response, err := ctx.Client.Do(request)
 
@@ -178,10 +180,11 @@ func (ctx HttpClientCtx) Request(authType AuthType, verb, url string, body io.Re
 		return nil, err
 	}
 
-	defer response.Body.Close()
-
-	dresponse, err := httputil.DumpResponse(response, true)
-	log.Trace.Print(string(dresponse))
+	if log.TracingEnabled {
+		defer response.Body.Close()
+		dresponse, err := httputil.DumpResponse(response, true)
+		log.Trace.Printf("%s %v", string(dresponse), err)
+	}
 
 	if response.StatusCode != 200 {
 		log.Trace.Printf("request failed with status %d\n", response.StatusCode)


### PR DESCRIPTION
Dumping the request/response is always enabled, which results in Out of memory on devices with little RAM when uploading large files (100MB).

This disbles dumping of the request if tracing is not enabled.
