### PR TITLE
Update the one-time code URL (fix #182)

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -63,7 +63,7 @@ func AuthHttpCtx(reAuth, nonInteractive bool) *transport.HttpClientCtx {
 
 func readCode() string {
 	reader := bufio.NewReader(os.Stdin)
-	fmt.Print("Enter one-time code (go to https://my.remarkable.com/connect/desktop): ")
+	fmt.Print("Enter one-time code (go to https://my.remarkable.com/device/connect/desktop): ")
 	code, _ := reader.ReadString('\n')
 
 	code = strings.TrimSuffix(code, "\n")

--- a/docs/tutorial-print-macosx.md
+++ b/docs/tutorial-print-macosx.md
@@ -47,7 +47,7 @@ The first time you run it, it will ask you to go to `https://my.remarkable.com/`
 You will see a prompt like this where you just need to introduce the activation code.
 
 ```bash
-Enter one-time code (go to https://my.remarkable.com/connect/desktop):
+Enter one-time code (go to https://my.remarkable.com/device/connect/desktop):
 ```
 
 If everything goes OK, you wil have access to the shell:


### PR DESCRIPTION
This PR contains the updated URL for obtaining onetime codes, which wasn't correct (see #182)