### PR TITLE
Add feature to replace PDF in existing document

### DIFF
--- a/model/document.go
+++ b/model/document.go
@@ -73,7 +73,7 @@ func CreateDirDocument(parent, name string) MetadataDocument {
 	}
 }
 
-func CreateUploadDocumentRequest(id string, entryType string) UploadDocumentRequest {
+func CreateUploadDocumentRequest(id string, entryType string, version int) UploadDocumentRequest {
 	if id == "" {
 		newId, err := uuid.NewV4()
 
@@ -86,18 +86,28 @@ func CreateUploadDocumentRequest(id string, entryType string) UploadDocumentRequ
 	return UploadDocumentRequest{
 		id,
 		entryType,
-		1,
+		version,
 	}
 }
 
 func CreateUploadDocumentMeta(id string, entryType, parent, name string) MetadataDocument {
-
 	return MetadataDocument{
 		ID:             id,
 		Parent:         parent,
 		VissibleName:   name,
 		Type:           entryType,
 		Version:        1,
+		ModifiedClient: time.Now().UTC().Format(time.RFC3339Nano),
+	}
+}
+
+func CreateUpdateDocumentMeta(id string, entryType, parent, name string, version int) MetadataDocument {
+	return MetadataDocument{
+		ID:             id,
+		Parent:         parent,
+		VissibleName:   name,
+		Type:           entryType,
+		Version:        version,
 		ModifiedClient: time.Now().UTC().Format(time.RFC3339Nano),
 	}
 }

--- a/shell/mput.go
+++ b/shell/mput.go
@@ -190,15 +190,15 @@ func putFilesAndDirs(pCtx *ShellCtxt, pC *ishell.Context, localDir string, depth
 				// Document does not exist.
 				treeFormat(pC, depth, index, lSize, tFS)
 				pC.Printf("uploading: [%s]...", name)
-				doc, err := pCtx.api.UploadDocument(pCtx.node.Id(), name)
+			}
+			doc, err := pCtx.api.UploadDocument(pCtx.node, name)
 
-				if err != nil {
-					pC.Err(fmt.Errorf("failed to upload file %s", name))
-				} else {
-					// Document uploaded successfully.
-					pC.Println(" complete")
-					pCtx.api.Filetree.AddDocument(*doc)
-				}
+			if err != nil {
+				pC.Err(fmt.Errorf("failed to upload file %s", name))
+			} else {
+				// Document uploaded successfully.
+				pC.Println(" complete")
+				pCtx.api.Filetree.AddDocument(*doc)
 			}
 
 		}

--- a/shell/put.go
+++ b/shell/put.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/abiosoft/ishell"
-	"github.com/juruen/rmapi/util"
 )
 
 func putCmd(ctx *ShellCtxt) *ishell.Cmd {
@@ -21,8 +20,6 @@ func putCmd(ctx *ShellCtxt) *ishell.Cmd {
 
 			srcName := c.Args[0]
 
-			docName, _ := util.DocPathToName(srcName)
-
 			node := ctx.node
 			var err error
 
@@ -35,17 +32,9 @@ func putCmd(ctx *ShellCtxt) *ishell.Cmd {
 				}
 			}
 
-			_, err = ctx.api.Filetree.NodeByPath(docName, node)
-			if err == nil {
-				c.Err(errors.New("entry already exists"))
-				return
-			}
+			c.Printf("uploading: [%s]...\n", srcName)
 
-			c.Printf("uploading: [%s]...", srcName)
-
-			dstDir := node.Id()
-
-			document, err := ctx.api.UploadDocument(dstDir, srcName)
+			document, err := ctx.api.UploadDocument(node, srcName)
 
 			if err != nil {
 				c.Err(fmt.Errorf("Failed to upload file [%s] %v", srcName, err))


### PR DESCRIPTION
The use case here is to use something like https://github.com/klimeryk/recalendar and generate the calendar e.g. every day, updated from Google Calendar or similar, but keep the existing annotations made on the file up until that point.

Unfortunately, for the new PDF to show up on the tablet, it seems to require deleting the files on the tablet under `.local/share/remarkable/xochitl` and restarting `xochitl`. But it works.