### PR TITLE
Fixed OTP url in CLI and docs

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -63,7 +63,7 @@ func AuthHttpCtx(reAuth, nonInteractive bool) *transport.HttpClientCtx {
 
 func readCode() string {
 	reader := bufio.NewReader(os.Stdin)
-	fmt.Print("Enter one-time code (go to https://my.remarkable.com/device/connect/desktop): ")
+	fmt.Print("Enter one-time code (go to https://my.remarkable.com/device/desktop/connect): ")
 	code, _ := reader.ReadString('\n')
 
 	code = strings.TrimSuffix(code, "\n")

--- a/docs/tutorial-print-macosx.md
+++ b/docs/tutorial-print-macosx.md
@@ -47,7 +47,7 @@ The first time you run it, it will ask you to go to `https://my.remarkable.com/`
 You will see a prompt like this where you just need to introduce the activation code.
 
 ```bash
-Enter one-time code (go to https://my.remarkable.com/device/connect/desktop):
+Enter one-time code (go to https://my.remarkable.com/device/desktop/connect):
 ```
 
 If everything goes OK, you wil have access to the shell:


### PR DESCRIPTION
The one-time password url was wrong, leading to a blank page.