### PR TITLE
fix for #225 send sync after all files have been uploaded on mput

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -15,9 +15,10 @@ type ApiCtx interface {
 	Filetree() *filetree.FileTreeCtx
 	FetchDocument(docId, dstPath string) error
 	CreateDir(parentId, name string) (*model.Document, error)
-	UploadDocument(parentId string, sourceDocPath string) (*model.Document, error)
+	UploadDocument(parentId string, sourceDocPath string, notify bool) (*model.Document, error)
 	MoveEntry(src, dstDir *model.Node, name string) (*model.Node, error)
 	DeleteEntry(node *model.Node) error
+	SyncComplete() error
 	Nuke() error
 }
 

--- a/api/sync10/api.go
+++ b/api/sync10/api.go
@@ -199,7 +199,7 @@ func (ctx *ApiCtx) MoveEntry(src, dstDir *model.Node, name string) (*model.Node,
 }
 
 // UploadDocument uploads a local document given by sourceDocPath under the parentId directory
-func (ctx *ApiCtx) UploadDocument(parentId string, sourceDocPath string) (*model.Document, error) {
+func (ctx *ApiCtx) UploadDocument(parentId string, sourceDocPath string, notify bool) (*model.Document, error) {
 	name, ext := util.DocPathToName(sourceDocPath)
 
 	if name == "" {
@@ -313,4 +313,9 @@ func DocumentsFileTree(http *transport.HttpClientCtx) (*filetree.FileTreeCtx, er
 	}
 
 	return &fileTree, nil
+}
+
+// SyncComplete does nothing for this version
+func (ctx *ApiCtx) SyncComplete() error {
+	return nil
 }

--- a/shell/mput.go
+++ b/shell/mput.go
@@ -190,7 +190,7 @@ func putFilesAndDirs(pCtx *ShellCtxt, pC *ishell.Context, localDir string, depth
 				// Document does not exist.
 				treeFormat(pC, depth, index, lSize, tFS)
 				pC.Printf("uploading: [%s]...", name)
-				doc, err := pCtx.api.UploadDocument(pCtx.node.Id(), name)
+				doc, err := pCtx.api.UploadDocument(pCtx.node.Id(), name, false)
 
 				if err != nil {
 					pC.Err(fmt.Errorf("failed to upload file %s", name))
@@ -200,8 +200,12 @@ func putFilesAndDirs(pCtx *ShellCtxt, pC *ishell.Context, localDir string, depth
 					pCtx.api.Filetree().AddDocument(doc)
 				}
 			}
-
 		}
+	}
+
+	err = pCtx.api.SyncComplete()
+	if err != nil {
+		pC.Err(fmt.Errorf("failed to complete the sync: %v", err))
 	}
 
 	if localDir != "./" {

--- a/shell/put.go
+++ b/shell/put.go
@@ -46,7 +46,7 @@ func putCmd(ctx *ShellCtxt) *ishell.Cmd {
 
 			dstDir := node.Id()
 
-			document, err := ctx.api.UploadDocument(dstDir, srcName)
+			document, err := ctx.api.UploadDocument(dstDir, srcName, true)
 
 			if err != nil {
 				c.Err(fmt.Errorf("Failed to upload file [%s] %v", srcName, err))


### PR DESCRIPTION
the sync-complete api has rate limiting it seems. this fix calls it after all files have been uploaded on mput