### PR TITLE
Add dummy page record to fix sync issue

### DIFF
--- a/archive/zipdoc.go
+++ b/archive/zipdoc.go
@@ -104,6 +104,7 @@ func CreateZipDocument(id, srcPath string) (zipPath string, err error) {
 		pages = append(pages, pageID)
 	} else {
 		documentPath = fmt.Sprintf("%s.%s", id, ext)
+		pages = append(pages, "")
 	}
 
 	f, err := w.Create(documentPath)


### PR DESCRIPTION
Fixes #231 
For some reason, when this is missing the rM (and the app) will try to upload the file right after downloading, and it would always fail.