### PR TITLE
Make api/auth more suitable to be used as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,4 +208,5 @@ rMAPI will set the exit code to `0` if the command succeedes, or `1` if it fails
 - `RMAPI_THUMBNAILS`: generate a thumbnail of the first page of a pdf document
 - `RMAPI_AUTH`: override the default authorization url
 - `RMAPI_DOC`: override the default document storage url
-- `RMAPI_HOST`: override all urls 
+- `RMAPI_HOST`: override all urls
+- `RMAPI_DEVICE_CODE`: one-time code for non-interactive usage

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/stretchr/testify v1.5.1
 	github.com/unidoc/unipdf/v3 v3.6.1
 	golang.org/x/image v0.0.0-20200119044424-58c23975cae1 // indirect
-	golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f // indirect
+	golang.org/x/sys v0.0.0-20220825204002-c680a09ffe64 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.2.8
 )

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f h1:gWF768j/LaZugp8dyS4UwsslYCYz9XgFxvlgsn0n9H8=
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220825204002-c680a09ffe64 h1:UiNENfZ8gDvpiWw7IpOMQ27spWmThO1RwwdQVbJahJM=
+golang.org/x/sys v0.0.0-20220825204002-c680a09ffe64/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=


### PR DESCRIPTION
Hi!

I'd like to use the api/auth part of of this package as a dependency. Basically i made two things to make that easier:

1) The one-time code for initial device token generation can be optionally supplied via `RMAPI_DEVICE_CODE`. I think that's good for the non-interactive usage of rmapi as well.

2) Instead of trying to authenticate with a expired user token, `userTokenExpires` checks if the token is expired or expires soon. It seems like (I haven't really checked this thoroughly tbh) if the rmapi shell is started just before the current user token is about to expire, there is no re-auth mechanism. Hence this change would also be nice for shell users...

To be able to work on this package on macOS Monterey with a M1 chip, i had to bump golang.org/x/sys to a newer version.

The PR is draft mode, because i'm not sure if there are differences regarding the authentication between the two API versions (See `TODO` in `userTokenExpires`). Since my RM Cloud account is on the newer API, i can't test it unfortunately.

> Unfortunately, the rmapi contributors are still on the old protocol and this makes it more difficult to test the new protocol's implementation.

Is this still the case? I'd love to support you with testing/verification.

Br, Thomas