### PR TITLE
annotations: tweak export brush size

### DIFF
--- a/annotations/pdf.go
+++ b/annotations/pdf.go
@@ -157,7 +157,7 @@ func (p *PdfGenerator) Generate() error {
 						path = path.AppendPoint(draw.NewPoint(x1, c.Height()-y1))
 					}
 
-					contentCreator.Add_w(float64(line.BrushSize / 100))
+					contentCreator.Add_w(float64(line.BrushSize * 6.0 - 10.8))
 
 					switch line.BrushColor {
 					case rm.Black:


### PR DESCRIPTION
The lines were previously very thin in all cases.
(So thin that my printer refused to print them correctly).

New adjustment values are eyeballed to match what's on the tablet.

GitHub: closes #167

---

Comparison, with old export below and new export above:

![IMG_20220903_130622](https://user-images.githubusercontent.com/1449319/188268024-041febfa-6ab9-4db3-911e-e447734754e1.jpg)
