### PR TITLE
fix synccomplete in mput

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -18,7 +18,7 @@ import (
 type ApiCtx interface {
 	Filetree() *filetree.FileTreeCtx
 	FetchDocument(docId, dstPath string) error
-	CreateDir(parentId, name string) (*model.Document, error)
+	CreateDir(parentId, name string, notify bool) (*model.Document, error)
 	UploadDocument(parentId string, sourceDocPath string, notify bool) (*model.Document, error)
 	MoveEntry(src, dstDir *model.Node, name string) (*model.Node, error)
 	DeleteEntry(node *model.Node) error

--- a/api/auth.go
+++ b/api/auth.go
@@ -43,7 +43,7 @@ func AuthHttpCtx(reAuth, nonInteractive bool) *transport.HttpClientCtx {
 	if authTokens.UserToken == "" || reAuth {
 		userToken, err := newUserToken(&httpClientCtx)
 
-		if err == transport.UnAuthorizedError {
+		if err == transport.ErrUnauthorized {
 			log.Trace.Println("Invalid deviceToken, resetting")
 			authTokens.DeviceToken = ""
 		} else if err != nil {

--- a/api/sync10/api.go
+++ b/api/sync10/api.go
@@ -105,7 +105,7 @@ func (ctx *ApiCtx) FetchDocument(docId, dstPath string) error {
 }
 
 // CreateDir creates a remote directory with a given name under the parentId directory
-func (ctx *ApiCtx) CreateDir(parentId, name string) (*model.Document, error) {
+func (ctx *ApiCtx) CreateDir(parentId, name string, notify bool) (*model.Document, error) {
 	uploadRsp, err := ctx.uploadRequest("", model.DirectoryType)
 
 	if err != nil {

--- a/shell/mkdir.go
+++ b/shell/mkdir.go
@@ -48,7 +48,7 @@ func mkdirCmd(ctx *ShellCtxt) *ishell.Cmd {
 				parentId = ""
 			}
 
-			document, err := ctx.api.CreateDir(parentId, newDir)
+			document, err := ctx.api.CreateDir(parentId, newDir, true)
 
 			if err != nil {
 				c.Err(errors.New(fmt.Sprint("failed to create directory", err)))

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -23,7 +23,8 @@ type BodyString struct {
 	Content string
 }
 
-var UnAuthorizedError = errors.New("401 Unauthorized Error")
+var ErrUnauthorized = errors.New("401 Unauthorized")
+var ErrConflict = errors.New("409 Conflict")
 
 var RmapiUserAGent = "rmapi"
 
@@ -198,9 +199,11 @@ func (ctx HttpClientCtx) Request(authType AuthType, verb, url string, body io.Re
 	case http.StatusOK:
 		return response, nil
 	case http.StatusUnauthorized:
-		return response, UnAuthorizedError
+		return response, ErrUnauthorized
+	case http.StatusConflict:
+		return response, ErrConflict
 	default:
-		return response, errors.New(fmt.Sprintf("request failed with status %d", response.StatusCode))
+		return response, fmt.Errorf("request failed with status %d", response.StatusCode)
 	}
 }
 


### PR DESCRIPTION
- moved out the notification out of the recursive function
- don't sync on createdir in `mput`
- ignore synccomlete error if nothing was changed