### PR TITLE
Add file and page tags to the cache file

### DIFF
--- a/archive/file.go
+++ b/archive/file.go
@@ -87,25 +87,37 @@ type Layer struct {
 	Name string `json:"name"`
 }
 
+type FileTag struct {
+	Name      string `json:"name"`
+	Timestamp int    `json:"timestamp"`
+}
+
+type PageTag struct {
+	Name      string `json:"name"`
+	PageId    string `json:"pageId"`
+	Timestamp int    `json:"timestamp"`
+}
+
 // Content represents the structure of a .content json file.
 type Content struct {
 	DummyDocument bool          `json:"dummyDocument"`
 	ExtraMetadata ExtraMetadata `json:"extraMetadata"`
 
 	// FileType is "pdf", "epub" or empty for a simple note
-	FileType       string `json:"fileType"`
-	FontName       string `json:"fontName"`
-	LastOpenedPage int    `json:"lastOpenedPage"`
-	LineHeight     int    `json:"lineHeight"`
-	Margins        int    `json:"margins"`
+	FileType       string    `json:"fileType"`
+	FileTags       []FileTag `json:"fileTags"`
+	FontName       string    `json:"fontName"`
+	LastOpenedPage int       `json:"lastOpenedPage"`
+	LineHeight     int       `json:"lineHeight"`
+	Margins        int       `json:"margins"`
 	// Orientation can take "portrait" or "landscape".
 	Orientation string `json:"orientation"`
 	PageCount   int    `json:"pageCount"`
 	// Pages is a list of page IDs
-	Pages          []string `json:"pages"`
-	Tags           []string `json:"pageTags"`
-	RedirectionMap []int    `json:"redirectionPageMap"`
-	TextScale      int      `json:"textScale"`
+	Pages          []string  `json:"pages"`
+	Tags           []PageTag `json:"pageTags"`
+	RedirectionMap []int     `json:"redirectionPageMap"`
+	TextScale      int       `json:"textScale"`
 
 	Transform Transform `json:"transform"`
 }
@@ -147,13 +159,15 @@ type MetadataFile struct {
 	CollectionType string `json:"type"`
 	Parent         string `json:"parent"`
 	//LastModified in milliseconds
-	LastModified     string `json:"lastModified"`
-	LastOpened       string `json:"lastOpened"`
-	LastOpenedPage   int    `json:"lastOpenedPage"`
-	Version          int    `json:"version"`
-	Pinned           bool   `json:"pinned"`
-	Synced           bool   `json:"synced"`
-	Modified         bool   `json:"modified"`
-	Deleted          bool   `json:"deleted"`
-	MetadataModified bool   `json:"metadatamodified"`
+	LastModified     string   `json:"lastModified"`
+	LastOpened       string   `json:"lastOpened"`
+	LastOpenedPage   int      `json:"lastOpenedPage"`
+	Version          int      `json:"version"`
+	Pinned           bool     `json:"pinned"`
+	Synced           bool     `json:"synced"`
+	Modified         bool     `json:"modified"`
+	Deleted          bool     `json:"deleted"`
+	MetadataModified bool     `json:"metadatamodified"`
+	FileTags         []string `json:"fileTags"`
+	PageTags         []string `json:"pageTags"`
 }


### PR DESCRIPTION
I'm working on a personal project that will require inspecting files that have specific tags on them. As a part of doing that, I have modified `rmapi` to include the names of the tags that have been applied to the top level file or to specific pages within a file.

This may address some what is desired in issue #249.

The file tags are in the `fileTags` field.
```json
"fileTags": [
    {
        "name": "Daily",
        "timestamp": 1655955509272
    }
]
```

The page tags are in the `pageTags` field.
```json
"pageTags": [
    {
        "name": "Planning",
        "pageId": "016892c0-1a4c-44e2-93d3-23b1f111a858",
        "timestamp": 1670176484275
    }
]
```

The updated cache file entry for a file with tags will look like the following:
```json
{
    "coverPageNumber": 0,
    "documentMetadata": {
    },
    "dummyDocument": false,
    "extraMetadata": {
        "LastBallpointColor": "Black",
        "LastBallpointSize": "2",
        "LastBallpointv2Color": "Black",
        "LastBallpointv2Size": "2",
        "LastCalligraphyColor": "Black",
        "LastCalligraphySize": "2",
        "LastClearPageColor": "Black",
        "LastClearPageSize": "2",
        "LastEraseSectionColor": "Black",
        "LastEraseSectionSize": "2",
        "LastEraserColor": "Black",
        "LastEraserSize": "1",
        "LastEraserTool": "EraseSection",
        "LastFinelinerColor": "Black",
        "LastFinelinerSize": "2",
        "LastFinelinerv2Color": "Black",
        "LastFinelinerv2Size": "2",
        "LastHighlighterColor": "Black",
        "LastHighlighterSize": "2",
        "LastHighlighterv2Color": "Black",
        "LastHighlighterv2Size": "2",
        "LastMarkerColor": "Black",
        "LastMarkerSize": "2",
        "LastMarkerv2Color": "Black",
        "LastMarkerv2Size": "3",
        "LastPaintbrushColor": "Black",
        "LastPaintbrushSize": "2",
        "LastPaintbrushv2Color": "Gray",
        "LastPaintbrushv2Size": "3",
        "LastPen": "Ballpointv2",
        "LastPencilColor": "Black",
        "LastPencilSize": "2",
        "LastPencilv2Color": "Black",
        "LastPencilv2Size": "2",
        "LastReservedPenColor": "Black",
        "LastReservedPenSize": "2",
        "LastSelectionToolColor": "Black",
        "LastSelectionToolSize": "2",
        "LastSharpPencilColor": "Black",
        "LastSharpPencilSize": "2",
        "LastSharpPencilv2Color": "Black",
        "LastSharpPencilv2Size": "2",
        "LastSolidPenColor": "Black",
        "LastSolidPenSize": "2",
        "LastTool": "SelectionTool",
        "LastUndefinedColor": "Black",
        "LastUndefinedSize": "2",
        "LastZoomToolColor": "Black",
        "LastZoomToolSize": "2"
    },
    "fileType": "notebook",
    "fontName": "",
    "formatVersion": 1,
    "lineHeight": -1,
    "margins": 100,
    "orientation": "portrait",
    "originalPageCount": -1,
    "pageCount": 5,
    "pageTags": [
        {
            "name": "Planning",
            "pageId": "016892c0-1a4c-44e2-93d3-23b1f111a858",
            "timestamp": 1670176484275
        }
    ],
    "pages": [
        "701d6ba6-c3cc-4bb2-9424-c6fe546979f8",
        "5527ba53-ef9f-4b5d-a35a-1cb768608567",
        "016892c0-1a4c-44e2-93d3-23b1f111a858",
        "37b227c5-6f06-44a9-a175-94ff0018b988",
        "64124558-0ae7-40ef-96b4-b054ad34aa82"
    ],
    "redirectionPageMap": [
    ],
    "sizeInBytes": "3389175",
    "fileTags": [
        {
            "name": "Daily",
            "timestamp": 1655955509272
        }
    ],
    "textAlignment": "left",
    "textScale": 1
}
```