### PR TITLE
Add download destination support for the get command

### DIFF
--- a/shell/get.go
+++ b/shell/get.go
@@ -29,7 +29,12 @@ func getCmd(ctx *ShellCtxt) *ishell.Cmd {
 
 			c.Println(fmt.Sprintf("downloading: [%s]...", srcName))
 
-			err = ctx.api.FetchDocument(node.Document.ID, fmt.Sprintf("%s.zip", node.Name()))
+			if len(c.Args) > 1 {
+				dest := c.Args[1]
+				err = ctx.api.FetchDocument(node.Document.ID, fmt.Sprintf("%s/%s.zip", dest, node.Name()))
+			} else {
+				err = ctx.api.FetchDocument(node.Document.ID, fmt.Sprintf("%s.zip", node.Name()))
+			}
 
 			if err == nil {
 				c.Println("OK")


### PR DESCRIPTION
The `FetchDocument` function supports a parameter that allows control of the download destination. However, this functionality is not exposed with the `get` command meaning files are downloaded to the current working directory by default. This PR exposes an optional parameter for the `get` command that allows control over the download destination of the file.