### PR TITLE
Update tutorial-print-macosx.md - Release 0.0.25

### DIFF
--- a/docs/tutorial-print-macosx.md
+++ b/docs/tutorial-print-macosx.md
@@ -19,7 +19,7 @@ Use `terminal` or `iterm` to get a terminal to run commands from it.
 Download `rmapi` with the following command:
 
 ```bash
-curl -L  https://github.com/juruen/rmapi/releases/download/v0.0.24/rmapi-macosx.zip -o rmapi.zip -o rmapi.zip
+curl -L  https://github.com/juruen/rmapi/releases/download/v0.0.25/rmapi-macosx.zip -o rmapi.zip
 ```
 
 Alternatively, you can build it from sources.


### PR DESCRIPTION
Update documentation to most recent release and fix `Warning: Got more output options than URLs` message with `curl` command.